### PR TITLE
fix; use tpl() for template paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function main(o, config, configName, callback) {
                     delete toplevel.apiInfo;
                     for (let pa of config.perApi) {
                         let fnTemplate = Hogan.compile(pa.output);
-                        let template = Hogan.compile(ff.readFileSync('./templates/'+configName+'/'+pa.input,'utf8'));
+                        let template = Hogan.compile(ff.readFileSync(tpl(configName, pa.input), 'utf8'));
                         for (let api of model.apiInfo.apis) {
                             let cApi = Object.assign({},config.defaults,toplevel,api);
                             let filename = fnTemplate.render(cApi,config.partials);
@@ -98,7 +98,7 @@ function main(o, config, configName, callback) {
                     let cModels = clone(model.models); 
                     for (let pm of config.perModel) {
                         let fnTemplate = Hogan.compile(pm.output);
-                        let template = Hogan.compile(ff.readFileSync('./templates/'+configName+'/'+pm.input,'utf8'));
+                        let template = Hogan.compile(ff.readFileSync(tpl(configName, pm.input), 'utf8'));
                         for (let model of cModels) {
                             outer.models = [];
                             outer.models.push(model);
@@ -114,7 +114,7 @@ function main(o, config, configName, callback) {
                         for (let api of outer.apiInfo.apis) {
                             let cOperations = clone(api.operations);
                             let fnTemplate = Hogan.compile(po.output);
-                            let template = Hogan.compile(ff.readFileSync('./templates/'+configName+'/'+po.input,'utf8'));
+                            let template = Hogan.compile(ff.readFileSync(tpl(configName, po.input), 'utf8'));
                             for (let operation of cOperations) {
                                 model.operations = [];
                                 model.operations.push(operation);


### PR DESCRIPTION
This fixes cases of errors where `cg`  is invoked outside of its repository directory.


This is from a globally installed official v1.3.3 release:
```
$ cg --debug --verbose nodejs https://raw.githubusercontent.com/OAI/OpenAPI-Specification/e9c539d86f080f133aa35c3e7db33ef004496625/examples/v3.0/petstore.yaml
Loaded config nodejs
Loaded definition https://raw.githubusercontent.com/OAI/OpenAPI-Specification/e9c539d86f080f133aa35c3e7db33ef004496625/examples/v3.0/petstore.yaml
{ level: 'Valid',
  elementType: 'Context',
  elementId: 'None',
  message: 'No validation errors detected' }
Processing template index.mustache
Processing template index-gcf.mustache
Processing template package.mustache
Processing template README.mustache
Processing template swagger.mustache
Processing template writer.mustache
Making/cleaning output directories
Rendering index.js
Rendering index-gcf.js
Rendering package.json
Rendering README.md
Rendering api/swagger.yaml
Rendering utils/writer.js
fs.js:663
  return binding.open(pathModule.toNamespacedPath(path),
                 ^

Error: ENOENT: no such file or directory, open './templates/nodejs/controller.mustache'
    at Object.fs.openSync (fs.js:663:18)
    at Object.fs.readFileSync (fs.js:568:33)
    at /home/steveej/.npm-packages/lib/node_modules/openapi-codegen/index.js:87:57
    at next (/home/steveej/.npm-packages/lib/node_modules/openapi-codegen/node_modules/rimraf/rimraf.js:75:7)
    at FSReqWrap.CB [as oncomplete] (/home/steveej/.npm-packages/lib/node_modules/openapi-codegen/node_modules/rimraf/rimraf.js:111:9)
```