### PR TITLE
Fix CLI -t/--template option

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ function main(o, config, configName, callback) {
             let tx = config.transformations[t];
             if (tx.input) {
                 if (verbose) console.log('Processing template '+tx.input);
-                tx.template = ff.readFileSync(tpl(configName, tx.input),'utf8');
+                let template = config.templateDir ? path.resolve(config.templateDir, tx.input) : tpl(configName, tx.input);
+                tx.template = ff.readFileSync(template,'utf8');
             }
             actions.push(tx);
         }


### PR DESCRIPTION
The assumed behavior of the `--template` option seems to be allowing user to specify any path which stores custom templates.
But it seems like this option currently does not work.
https://github.com/Mermade/openapi-codegen/blob/f9f37551036d3980fd5199cc97607bddfccfb6f5/index.js#L21-L25
https://github.com/Mermade/openapi-codegen/blob/f9f37551036d3980fd5199cc97607bddfccfb6f5/index.js#L40-L43

I added small codes referencing the specified templates path.
