### PR TITLE
cpprest: Add conversion for bool in query param

### DIFF
--- a/templates/cpprest/apiclient-header.mustache
+++ b/templates/cpprest/apiclient-header.mustache
@@ -36,6 +36,7 @@ public:
     void setConfiguration(std::shared_ptr<ApiConfiguration> configuration);
 
     static utility::string_t parameterToString(utility::string_t value);
+    static utility::string_t parameterToString(bool value);
     static utility::string_t parameterToString(int32_t value);
     static utility::string_t parameterToString(int64_t value);
     static utility::string_t parameterToString(float value);

--- a/templates/cpprest/apiclient-source.mustache
+++ b/templates/cpprest/apiclient-source.mustache
@@ -31,6 +31,13 @@ utility::string_t ApiClient::parameterToString(utility::string_t value)
 {
     return value;
 }
+utility::string_t ApiClient::parameterToString(bool value)
+{
+    if (value) {
+      return utility::conversions::to_string_t("true");
+    }
+    return utility::conversions::to_string_t("false");
+}
 utility::string_t ApiClient::parameterToString(int64_t value)
 {
 	std::stringstream valueAsStringStream;


### PR DESCRIPTION
Due to c++ conversion rules, bools in query parameters were passed as 1
an 0 (using a bool -> int implicit conversion) instead of true and false.

The OpenAPI 3 spec has this to say about the value of a boolean:

> Boolean
> type: boolean represents two values: true and false. Note that truthy and
> falsy values such as "true", "", 0 or null are not considered boolean values.

This commit adds a util function to convert a bool query param into a
true or false as a query param.

Before:

  GET /foo?bar=0 HTTP/1.1

After:

  GET /foo?bar=false HTTP/1.1
