### PR TITLE
Add support for isMapConatiner and isArrayContainer

### DIFF
--- a/adaptor.js
+++ b/adaptor.js
@@ -936,7 +936,9 @@ function transform(api, defaults, callback) {
                         if (typeof schema[p] !== 'undefined') entry[p] = schema[p];
                     }
                     entry.isEnum = !!schema.enum;
-                    entry.isPrimitiveType = ((schema.type !== 'object') && (schema.type !== 'array'));
+                    entry.isListContainer = schema.type === 'array';
+                    entry.isMapContainer = schema.type === 'object';
+                    entry.isPrimitiveType = !entry.isListContainer && !entry.isMapContainer;
                     entry.isNotContainer = entry.isPrimitiveType;
                     if (entry.isEnum) entry.isNotContainer = false;
                     entry.isContainer = !entry.isNotContainer;

--- a/docs/modelProperties.md
+++ b/docs/modelProperties.md
@@ -154,3 +154,5 @@
 |modelPackage|model|Order||
 |hasEnums|model|false||
 |vars|model|[array]||
+|isMapContainer|model|false|boolean - set to true when container is a map|
+|isArrayContainer|model|false|boolean - set to true when container is a array|


### PR DESCRIPTION
according to [swagger-codegen documentation](https://github.com/swagger-api/swagger-codegen/wiki/Mustache-Template-Variables#mustache-template-variables-in-the-operation) and search in templates directory there should be `isMapConatiner` and `isArrayContainer` mustache variables. This PR sets the missing variables.
