### PR TITLE
fix(adaptor): add missing isEnum property to model

### DIFF
--- a/adaptor.js
+++ b/adaptor.js
@@ -909,6 +909,7 @@ function transform(api, defaults, callback) {
                 model.unescapedDescription = schema.description;
                 model.classFilename = obj.classPrefix+model.name;
                 model.modelPackage = model.name;
+                model.isEnum = !!schema.enum;
                 model.hasEnums = false;
                 model.vars = [];
                 walkSchema(schema,{},wsGetState,function(schema,parent,state){

--- a/adaptor.js
+++ b/adaptor.js
@@ -569,6 +569,14 @@ const markdownPPs = {
     }
 };
 
+function getSchemaType(schema) {
+    if (!schema.type && schema["x-oldref"]) {
+        return schema["x-oldref"].replace('#/components/schemas/', '');
+    }
+
+    return schema.type;
+}
+
 const typeMaps = {
     nop: function(type,required,schema) {
         return type;
@@ -588,8 +596,8 @@ const typeMaps = {
         if (result === 'integer') result = 'number';
         if (result === 'array') {
             result = 'Array';
-            if (schema.items && schema.items.type) {
-                result += '<'+typeMap(schema.items.type,false,schema.items)+'>';
+            if (schema.items) {
+                result += '<'+typeMap(getSchemaType(schema.items), false, schema.items)+'>';
             }
         }
         return result;
@@ -943,15 +951,10 @@ function transform(api, defaults, callback) {
                     entry.setter = Case.camel('set_'+entry.name);
                     entry.description = schema.description||'';
                     entry.unescapedDescription = entry.description;
-                    if (entry.name && !schema.type && schema["x-oldref"]) {
-                        entry.type = schema["x-oldref"].replace('#/components/schemas/', '');
-                    } else {
-                        entry.type = schema.type;
-                    }
                     entry.required = (parent.required && parent.required.indexOf(entry.name)>=0)||false;
                     entry.isNotRequired = !entry.required;
                     entry.readOnly = !!schema.readOnly;
-                    entry.type = typeMap(entry.type,entry.required,schema);
+                    entry.type = typeMap(getSchemaType(schema), entry.required, schema);
                     entry.dataType = entry.type; //camelCase for imported files
                     entry.datatype = entry.type; //lower for other files
                     entry.jsonSchema = safeJson(schema,null,2);

--- a/adaptor.js
+++ b/adaptor.js
@@ -944,7 +944,7 @@ function transform(api, defaults, callback) {
                     entry.description = schema.description||'';
                     entry.unescapedDescription = entry.description;
                     if (entry.name && !schema.type && schema["x-oldref"]) {
-                        entry.type = obj.modelPackage + '\\' + schema["x-oldref"].replace('#/components/schemas/', '');
+                        entry.type = schema["x-oldref"].replace('#/components/schemas/', '');
                     } else {
                         entry.type = schema.type;
                     }


### PR DESCRIPTION
fixes #89 

If we have the following openapi definition:

```yaml
...
definitions:
  MyEnum:
    type: string
    enum:
      - hello
      - world
...
```

In the previous version it wasn't possible to determine whether the `MyEnum` is an enum or not.
This PR adds the flag `isEnum` to a model object, so we can easily distinguish enum models from another ones.