### PR TITLE
Improve consistency with openapi-generator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,21 @@ First of all, many thanks for considering making a contribution to this project.
 
 Please **do not** include any changes to `package-lock.json` in your PRs, even if you are updating `package.json`. These changes are almost impossible to review for security implications. If necessary, `package-lock.json` will be regenerated and committed by a maintainer after your PR is merged.
 
+Please run the test before submitting your pull request.
+
+1. `npm run lint`
+1. `npm test`
+1. `bin/buildAll.sh`
+1. `npm i typescript@2.6.1 -g`
+1. `bin/checkJs.sh`
+1. `bin/checkTs.sh`
+1. `bin/checkLua.sh`
+1. `bin/checkGo.sh`
+1. `bin/checkRuby.sh`
+1. `bin/checkBash.sh`
+1. `bin/checkHaskell.sh`
+1. `bin/checkPython.sh`
+
 ## Configs
 
 The main thing we need is config files which control the process of which files are processed by a particular set of templates. Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,16 +10,8 @@ Please run the test before submitting your pull request.
 
 1. `npm run lint`
 1. `npm test`
-1. `bin/buildAll.sh`
-1. `npm i typescript@2.6.1 -g`
-1. `bin/checkJs.sh`
-1. `bin/checkTs.sh`
-1. `bin/checkLua.sh`
-1. `bin/checkGo.sh`
-1. `bin/checkRuby.sh`
-1. `bin/checkBash.sh`
-1. `bin/checkHaskell.sh`
-1. `bin/checkPython.sh`
+
+The code will run these tests as well as all generators on Travis CI on https://travis-ci.org/github/Mermade/openapi-codegen
 
 ## Configs
 

--- a/adaptor.js
+++ b/adaptor.js
@@ -450,9 +450,7 @@ function convertOperation(op,verb,path,pathItem,obj,api) {
     operation.queryParams = convertArray(operation.queryParams);
     operation.headerParams = convertArray(operation.headerParams);
     operation.pathParams = convertArray(operation.pathParams);
-    console.log("formParams for" + operation.nickname, operation.formParams);
     operation.formParams = convertArray(operation.formParams);
-    console.log("formParams", operation.formParams);
     operation.bodyParams = convertArray(operation.bodyParams);
     operation.allParams = convertArray(operation.allParams);
     operation.examples = convertArray(operation.examples);

--- a/adaptor.js
+++ b/adaptor.js
@@ -978,22 +978,22 @@ function transform(api, defaults, callback) {
                     entry.defaultValue = schema.default;
 
                     if (entry.isEnum) {
-                        model.allowableValues = {};
-                        model.allowableValues.enumVars = [];
-                        model["allowableValues.values"] = schema.enum;
-                        model.allowableValues.values = schema.enum;
+                        model.hasEnums = true;
+                        entry.allowableValues = {};
+                        entry.allowableValues.enumVars = [];
+                        entry["allowableValues.values"] = schema.enum;
+                        entry.allowableValues.values = schema.enum;
                         for (let v of schema.enum) {
                             let e = { name: v, nameInCamelCase: Case.camel(v), value: '"'+v+'"' }; // insane, why aren't the quotes in the template?
-                            model.allowableValues.enumVars.push(e);
+                            entry.allowableValues.enumVars.push(e);
                         }
-                        model.allowableValues.enumVars = convertArray(model.allowableValues.enumVars);
+                        entry.allowableValues.enumVars = convertArray(entry.allowableValues.enumVars);
                     }
 
                     if (entry.name && state.depth<=1) {
                         entry.nameInCamelCase = Case.pascal(entry.name); // for erlang-client
                         entry.datatypeWithEnum = s+'.'+entry.name+'Enum';
                         entry.enumName = entry.name+'Enum';
-                        model.hasEnums = true;
                         model.vars.push(entry);
                     }
                 });

--- a/adaptor.js
+++ b/adaptor.js
@@ -962,6 +962,7 @@ function transform(api, defaults, callback) {
                         if (typeof schema[p] !== 'undefined') entry[p] = schema[p];
                     }
                     entry.isEnum = !!schema.enum;
+                    entry.isString = schema.type == 'string';
                     entry.isListContainer = schema.type === 'array';
                     entry.isMapContainer = schema.type === 'object';
                     entry.isPrimitiveType = !entry.isListContainer && !entry.isMapContainer;
@@ -973,6 +974,9 @@ function transform(api, defaults, callback) {
                     }
                     if ((schema.type === 'array') && schema.items && schema.items["x-oldref"]) {
                         entry.itemsComplexType = schema.items["x-oldref"].replace('#/components/schemas/','');
+                    }
+                    if ((schema.type === 'array') && schema.items && schema.items.type === 'string') {
+                        entry.itemsComplexType = 'string';
                     }
                     entry.dataFormat = schema.format;
                     entry.defaultValue = schema.default;

--- a/adaptor.js
+++ b/adaptor.js
@@ -277,17 +277,11 @@ function convertOperation(op,verb,path,pathItem,obj,api) {
             if (type === 'application/x-www-form-urlencoded') {
                 for (const paramName in contentType.schema.properties) {
                     const prop = contentType.schema.properties[paramName];
-                    const parameter = {
-                        paramName: paramName,
-                        baseName: paramName,
-                        type: prop.type,
-                        dataType: prop.type,
-                        datatype: prop.type,
-                        baseType: prop.type,
-                        format: prop.format,
-                        dataFormat: prop.format,
-                        required: contentType.schema.required.indexOf(paramName) >= 0
-                    };
+                    const parameter = {};
+                    parameter.paramName = parameter.baseName = paramName;
+                    parameter.type = parameter.dataType = parameter.datatype = parameter.baseType = prop.type;
+                    parameter.format = parameter.dataFormat = prop.format;
+                    parameter.required = contentType.schema.required && contentType.schema.required.indexOf(paramName) >= 0;
                     parameter.isBoolean = (parameter.type === 'boolean');
                     parameter.isDate = (parameter.dataFormat === 'date');
                     parameter.isDateTime = (parameter.dataFormat === 'date-time');

--- a/adaptor.js
+++ b/adaptor.js
@@ -1003,8 +1003,8 @@ function transform(api, defaults, callback) {
                     entry.isNotContainer = entry.isPrimitiveType;
                     if (entry.isEnum) entry.isNotContainer = false;
                     entry.isContainer = !entry.isNotContainer;
-                    if ((schema.type === 'object') && schema.properties && schema.properties["x-oldref"]) {
-                        entry.complexType = schema.properties["x-oldref"].replace('#/components/schemas/','');
+                    if ((schema.type === 'object') && schema["x-oldref"]) {
+                        entry.complexType = schema["x-oldref"].replace('#/components/schemas/','');
                     }
                     if ((schema.type === 'array') && schema.items && schema.items["x-oldref"]) {
                         entry.itemsComplexType = schema.items["x-oldref"].replace('#/components/schemas/','');

--- a/adaptor.js
+++ b/adaptor.js
@@ -287,11 +287,16 @@ function convertOperation(op,verb,path,pathItem,obj,api) {
                     parameter.isDateTime = (parameter.dataFormat === 'date-time');
                     parameter.isBodyParam = false;
                     parameter.isFormParam = true;
-                    operation.allParams.push(parameter);
-                    operation.formParams.push(parameter);
+                    operation.allParams.push(clone(parameter));
+                    operation.formParams.push(clone(parameter));
+                    if (parameter.required) operation.hasRequiredParams = true;
+                    if (!parameter.required) operation.hasOptionalParams = true;
                 }
                 operation.hasParams = true;
                 operation.hasFormParams = true;
+                let mt = { mediaType: Object.keys(op.requestBody.content)[0] };
+                operation.consumes.push(mt);
+                operation.hasConsumes = true;
             } else {
                 operation.bodyParam = {};
                 operation.bodyParam.isHeaderParam = false;
@@ -445,7 +450,9 @@ function convertOperation(op,verb,path,pathItem,obj,api) {
     operation.queryParams = convertArray(operation.queryParams);
     operation.headerParams = convertArray(operation.headerParams);
     operation.pathParams = convertArray(operation.pathParams);
+    console.log("formParams for" + operation.nickname, operation.formParams);
     operation.formParams = convertArray(operation.formParams);
+    console.log("formParams", operation.formParams);
     operation.bodyParams = convertArray(operation.bodyParams);
     operation.allParams = convertArray(operation.allParams);
     operation.examples = convertArray(operation.examples);

--- a/local.js
+++ b/local.js
@@ -75,8 +75,13 @@ function main(o, config, configName, callback) {
                 }
                 for (let action of actions) {
                     if (verbose) console.log('Rendering '+action.output);
-                    let template = Hogan.compile(action.template);
-                    let content = template.render(model,config.partials);
+                    let content;
+                    if (config.generator && config.generator.render) {
+                        content = config.generator.render(action.template, model, config.partials);
+                    } else {
+                        let template = Hogan.compile(action.template);
+                        content = template.render(model,config.partials);
+                    }
                     ff.createFile(path.join(outputDir,subDir,action.output),content,'utf8');
                 }
                 if (config.touch) { // may not now be necessary


### PR DESCRIPTION
I have four commits:

* allowableValues.enumvars was set on model and not on property, meaning that a model with two enums would fial
* property.isString and property.itemsComplexType = 'string' will improve compatibility with openapi-generator templates
* I wanted to use Handlebars for some templates. By adding render to the generator specified in the configFile, you can plug in any templating system you want
* operation.requestBody didn't support application/x-www-form-urlencoded

I tried to make the commits as small as possible, but I realize that the use of confiig.generator.render probably would be better by making Hogan into a default and using config.generator.render instead of Hogan in adaptor.transform