### PR TITLE
feat: enable skipping creation of a license file

### DIFF
--- a/local.js
+++ b/local.js
@@ -97,12 +97,17 @@ function main(o, config, configName, callback) {
                         }
                     }
                 }
-                if (config.apache) {
-                    ff.createFile(path.join(outputDir,subDir,'LICENSE'),ff.readFileSync(tpl({}, '_common', 'LICENSE'),'utf8'),'utf8');
+
+                // generate license by default
+                if (typeof config.license === 'undefined') {
+                    config.license = true;
                 }
-                else {
-                    ff.createFile(path.join(outputDir,subDir,'LICENSE'),ff.readFileSync(tpl({}, '_common', 'UNLICENSE'),'utf8'),'utf8');
+
+                if (config.license) {
+                    const licenseType = config.apache ? 'LICENSE' : 'UNLICENSE';
+                    ff.createFile(path.join(outputDir, subDir, 'LICENSE'), ff.readFileSync(tpl({}, '_common', licenseType), 'utf8'), 'utf8');
                 }
+
                 let outer = model;
 
                 if (config.perApi) {

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -14,6 +14,10 @@
             "type": "string",
             "description": "Name of the config. Currently unused."
         },
+        "license": {
+            "type": "boolean",
+            "description": "Whether to create a license file"
+        },
         "apache": {
             "type": "boolean",
             "description": "Whether to include the Apache-2.0 license instead of the Unlicense"


### PR DESCRIPTION
It would be useful to allow users that have custom templates and configs to disable generation of the standard license file like `LICENSE` (Apache) and `UNLICENSE`. So that they can provide a custom license file via `touch` or `transformations`.

The PR doesn't introduce any breaking changes. If the new option `license` isn't set, then a license file will be generated as it was before.

