### PR TITLE
Remove debugging statement in adaptor.js

### DIFF
--- a/adaptor.js
+++ b/adaptor.js
@@ -840,7 +840,6 @@ function transform(api, defaults, callback) {
         };
     };
     obj.this = function() {
-        console.warn('this called');
         return thisFunc(this.paramName);
     };
     obj.length = function() {


### PR DESCRIPTION
Running `npx -q -p openapi-codegen cg python path/to/my/spec.yaml` prints `this called` many times. Guessing this is a debugging statement that snuck in. :smile: 